### PR TITLE
fix: don't require specific fix version

### DIFF
--- a/problem/go.mod
+++ b/problem/go.mod
@@ -1,3 +1,3 @@
 module github.com/GodsBoss/g/problem
 
-go 1.22.5
+go 1.22


### PR DESCRIPTION
This change allows modules that import this package to also not specify the fix version.