### PR TITLE
Fix type constraints for bitseq and mathseq

### DIFF
--- a/seq/bitseq/bit.go
+++ b/seq/bitseq/bit.go
@@ -7,7 +7,7 @@ import (
 
 // Integer is a constraint for any of the builtin integer types.
 type Integer interface {
-	int | int8 | int16 | int32 | int64 | uint | uint8 | uint16 | uint32 | uint64
+	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64
 }
 
 // And combines all items from sequence via bitwise AND. Returns -1 (all bits set to 1) if the sequence is empty.

--- a/seq/bitseq/bit.go
+++ b/seq/bitseq/bit.go
@@ -5,7 +5,7 @@ import (
 	"iter"
 )
 
-// Integer is a constraint for any of the builtin integer types.
+// Integer is a constraint for any of the integer types.
 type Integer interface {
 	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64
 }

--- a/seq/bitseq/bit.go
+++ b/seq/bitseq/bit.go
@@ -1,3 +1,4 @@
+// Package bitseq applies bitwise operations to sequences of integers.
 package bitseq
 
 import (

--- a/seq/boolseq/bool.go
+++ b/seq/boolseq/bool.go
@@ -1,3 +1,4 @@
+// Package boolseq contains helpers for sequences of booleans.
 package boolseq
 
 import "iter"

--- a/seq/iterate/repeat.go
+++ b/seq/iterate/repeat.go
@@ -81,11 +81,13 @@ func Repeat[Value any](count int, reusable bool) func(iter.Seq[Value]) iter.Seq[
 	}
 }
 
+// Useful count constants to use with Repeat.
 const (
 	Never         = 0
 	InfiniteTimes = -1
 )
 
+// Determine whether a sequence is reusable when calling Repeat.
 const (
 	IsReusable    = true
 	IsNotReusable = false

--- a/seq/iterate2/repeat.go
+++ b/seq/iterate2/repeat.go
@@ -83,11 +83,13 @@ func Repeat[First any, Second any](count int, reusable bool) func(iter.Seq2[Firs
 	}
 }
 
+// Useful count constants to use with Repeat.
 const (
 	Never         = 0
 	InfiniteTimes = -1
 )
 
+// Determine whether a sequence is reusable when calling Repeat.
 const (
 	IsReusable    = true
 	IsNotReusable = false

--- a/seq/mathseq/calc.go
+++ b/seq/mathseq/calc.go
@@ -6,7 +6,7 @@ import (
 
 // Numeric is a constraint that contains all numeric types.
 type Numeric interface {
-	float32 | float64 | int | int8 | int16 | int32 | int64 | uint | uint8 | uint16 | uint32 | uint64
+	~float32 | ~float64 | ~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64
 }
 
 // Sum returns the sum of all the numbers from the sequence. If the sequence is empty, 0 is returned.

--- a/seq/mathseq/docs.go
+++ b/seq/mathseq/docs.go
@@ -1,0 +1,2 @@
+// Package mathseq operates on numerical sequences.
+package mathseq

--- a/seq/throttle/throttle.go
+++ b/seq/throttle/throttle.go
@@ -1,3 +1,4 @@
+// Package throttle allows for throttling iterators.
 package throttle
 
 import (

--- a/seq/ticker/ticker.go
+++ b/seq/ticker/ticker.go
@@ -1,3 +1,4 @@
+// Package ticker provides a sequence based on ticks.
 package ticker
 
 import (


### PR DESCRIPTION
For some reason the type constraints `Numeric` and `Integer` only allowed for the base types (e.g. `int`), but not derived types (e.g. `type foo int`). Technically, this is a breaking change, but these should have been like that from the beginning and the module isn't used anywhere yet.